### PR TITLE
add get all users situation

### DIFF
--- a/src/components/login-dropdown.tsx
+++ b/src/components/login-dropdown.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 
-import { logout, loginUser as login } from '../state/actions';
+import { logout, loginUser as login, fetchUsers } from '../state/actions';
 import { getCurrentUser } from '../state/reducer';
 import sdk from '../sdk';
 
@@ -11,10 +11,12 @@ type Props = {
 	onRegister: any;
 	loggedIn: boolean;
 	username: string;
+	fetchUsers: any;
 };
 
 class LoginDropdown extends React.Component<Props> {
 	async componentDidMount() {
+		this.props.fetchUsers();
 		try {
 			let login = localStorage.getItem('login');
 			console.error(login);
@@ -101,4 +103,6 @@ function mapStateToProps(state) {
 	return { username, loggedIn };
 }
 
-export default connect<any, any, any>(mapStateToProps, { login, logout })(LoginDropdown);
+export default connect<any, any, any>(mapStateToProps, { login, logout, fetchUsers })(
+	LoginDropdown
+);

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -163,6 +163,14 @@ class BopSdk {
 		return _.first(resp) as api.Metadata;
 	};
 
+	getAllUsers = async ({ limit = 5000 } = {}): Promise<any> => {
+		const endpoint = `${config.swaggerHost}/users?limit=${limit}`;
+		const users = await (await fetch(endpoint)).json();
+		const normalized = normalize(users, [user]);
+
+		return { ...normalized.entities };
+	};
+
 	getUser = async (optionalUsername, optionalPassword): Promise<any> => {
 		const getU = api.UsersApiFp.usersGet({
 			username: `eq.${optionalUsername}`,

--- a/src/state/actions.ts
+++ b/src/state/actions.ts
@@ -40,6 +40,7 @@ export const shuffleSongs = createAction(SHUFFLE_SONGS);
 export const loginUserFailure = createAction<UserPayload>(LOGIN_USER_FAILURE);
 export type EventsPayload = { events };
 export const fetchEvents = createAction(FETCH_EVENTS, sdk.getEvents);
+export const fetchUsers = createAction(ADD_ENTITIES, sdk.getAllUsers);
 
 /* Thunk Async Actions */
 


### PR DESCRIPTION
right now only piggybacking off the /songs api. this makes a dedicated /users request to get all users.

shouldn't be an issue to get them all for a long time.
at that point should be trivial to request them one off since we have all the ids we need anyway